### PR TITLE
Update tauri.conf.json

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "distDir": "../dist",
-    "devPath": "http://localhost:4000",
+    "devPath": "../dist",
     "beforeDevCommand": "",
     "beforeBuildCommand": ""
   },


### PR DESCRIPTION
point devPath at a relative folder to use the onboard injection. otherwise you will have to start a `localhost:4000` server yourself. i just noticed our docs are not clear about this.